### PR TITLE
Fix node socket registration

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,11 +10,12 @@ bl_info = {
 }
 
 import bpy
-from .node_tree import SCENE_NODES_TREE
+from .node_tree import SceneNodeSocket, SCENE_NODES_TREE
 from .nodes.create_scene import NODE_OT_create_scene
 from .nodes.render_scene import NODE_OT_render_scene
 
 classes = (
+    SceneNodeSocket,
     SCENE_NODES_TREE,
     NODE_OT_create_scene,
     NODE_OT_render_scene,


### PR DESCRIPTION
## Summary
- add `SceneNodeSocket` to the addon registration so it unregisters cleanly and avoids duplicate registration errors

## Testing
- `python -m py_compile __init__.py node_tree.py nodes/create_scene.py nodes/render_scene.py`

------
https://chatgpt.com/codex/tasks/task_e_6854ed1ed29c83309e146fcd83870fe5