### PR TITLE
Fix SceneNodeSocket registration error

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -5,6 +5,9 @@ class SceneNodeSocket(NodeSocket):
     bl_idname = 'SceneNodeSocketType'
     bl_label = 'Scene Socket'
     # socket color
+    def draw(self, context, layout, node, text):
+        layout.label(text=text)
+
     def draw_color(self, context, node):
         return (0.6, 0.8, 0.2, 1.0)
 


### PR DESCRIPTION
## Summary
- add missing `draw` method to `SceneNodeSocket` to satisfy Blender 4.x requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ee3ed16c83309c2547c7fa8ae117