### PR TITLE
Fix missing nodes in add menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Scene_Nodes_Addon
+# Scene Nodes Addon
+
+This is a simple example addon that demonstrates a basic node tree for procedural scene management in Blender.
+
+## Installation
+
+1. Download or clone this repository.
+2. In Blender, go to *Edit > Preferences > Add-ons* and click *Install*.
+3. Select the directory containing this addon and enable **Scene Nodes**.
+
+## Usage
+
+Once enabled, open the *Geometry Node Editor* and switch the tree type to **Scene Nodes**. Use the **Add** menu to access the custom nodes:
+
+- **Create Scene** — outputs a new scene.
+- **Render Scene** — takes a scene input and renders it.
+
+These nodes are registered under the *Scene Nodes* category.

--- a/__init__.py
+++ b/__init__.py
@@ -10,6 +10,12 @@ bl_info = {
 }
 
 import bpy
+from nodeitems_utils import (
+    NodeCategory,
+    NodeItem,
+    register_node_categories,
+    unregister_node_categories,
+)
 from .node_tree import SceneNodeSocket, SCENE_NODES_TREE
 from .nodes.create_scene import NODE_OT_create_scene
 from .nodes.render_scene import NODE_OT_render_scene
@@ -21,15 +27,30 @@ classes = (
     NODE_OT_render_scene,
 )
 
+# node categories for the Add menu
+class SceneNodeCategory(NodeCategory):
+    @classmethod
+    def poll(cls, context):
+        return context.space_data.tree_type == SCENE_NODES_TREE.bl_idname
+
+node_categories = [
+    SceneNodeCategory('SCENE_NODES', 'Scene Nodes', items=[
+        NodeItem(NODE_OT_create_scene.bl_idname),
+        NodeItem(NODE_OT_render_scene.bl_idname),
+    ]),
+]
+
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
     bpy.types.Scene.scene_nodes_tree = bpy.props.PointerProperty(type=SCENE_NODES_TREE)
+    register_node_categories('SCENE_NODES', node_categories)
 
 def unregister():
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
     del bpy.types.Scene.scene_nodes_tree
+    unregister_node_categories('SCENE_NODES')
 
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
## Summary
- register node categories so nodes appear in Blender's Add menu
- document installation and usage instructions

## Testing
- `python3 -m py_compile __init__.py node_tree.py nodes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6854efc57fc0833081957004b55b8ebb