### PR TITLE
Implement scene creation and render nodes

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -1,9 +1,15 @@
 import bpy
 from bpy.types import NodeTree, Node, NodeSocket
 
+
+def _new_scene_property():
+    """Pointer property for storing a Blender Scene."""
+    return bpy.props.PointerProperty(name="Scene", type=bpy.types.Scene)
+
 class SceneNodeSocket(NodeSocket):
     bl_idname = 'SceneNodeSocketType'
     bl_label = 'Scene Socket'
+    scene: _new_scene_property()
     # socket color
     def draw(self, context, layout, node, text):
         layout.label(text=text)

--- a/nodes/create_scene.py
+++ b/nodes/create_scene.py
@@ -12,8 +12,21 @@ class NODE_OT_create_scene(Node):
         self.outputs.new('SceneNodeSocketType', "Scene")
 
     def update(self):
-        # placeholder: create a new scene on execution
-        pass
+        output = self.outputs.get("Scene")
+        if not output:
+            return
+
+        base_name = "Scene"
+        name = base_name
+        index = 1
+        # ensure unique scene name
+        while name in bpy.data.scenes:
+            name = f"{base_name}.{index:03d}"
+            index += 1
+
+        new_scene = bpy.data.scenes.new(name)
+        # store the created scene on the socket so it can be passed to other nodes
+        output.scene = new_scene
 
 def register():
     bpy.utils.register_class(NODE_OT_create_scene)

--- a/nodes/render_scene.py
+++ b/nodes/render_scene.py
@@ -12,8 +12,34 @@ class NODE_OT_render_scene(Node):
         self.inputs.new('SceneNodeSocketType', "Scene")
 
     def update(self):
-        # placeholder: trigger render on execution
-        pass
+        input_socket = self.inputs.get("Scene")
+        if not input_socket:
+            return
+
+        scene = None
+        # if the socket is linked, get the scene from the connected socket
+        if input_socket.is_linked:
+            for link in input_socket.links:
+                source = link.from_socket
+                scene = getattr(source, "scene", None)
+                if scene:
+                    break
+        else:
+            scene = getattr(input_socket, "scene", None)
+
+        if not scene:
+            return
+
+        window = bpy.context.window
+        if not window:
+            return
+
+        current_scene = window.scene
+        try:
+            window.scene = scene
+            bpy.ops.render.render()
+        finally:
+            window.scene = current_scene
 
 def register():
     bpy.utils.register_class(NODE_OT_render_scene)


### PR DESCRIPTION
## Summary
- add pointer property on `SceneNodeSocket` for storing a scene
- create new scenes in `NODE_OT_create_scene.update`
- render scenes in `NODE_OT_render_scene.update`

## Testing
- `python3 -m py_compile node_tree.py nodes/create_scene.py nodes/render_scene.py __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6854f2a1ef988330be9dfac143c36ebf