### PR TITLE
Add new scene management nodes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,15 +16,34 @@ from nodeitems_utils import (
     register_node_categories,
     unregister_node_categories,
 )
-from .node_tree import SceneNodeSocket, SCENE_NODES_TREE
+from .node_tree import (
+    SceneNodeSocket,
+    CollectionNodeSocket,
+    ObjectNodeSocket,
+    CameraNodeSocket,
+    MaterialNodeSocket,
+    WorldNodeSocket,
+    SCENE_NODES_TREE,
+)
 from .nodes.create_scene import NODE_OT_create_scene
 from .nodes.render_scene import NODE_OT_render_scene
+from .nodes.add_collection import NODE_OT_add_collection
+from .nodes.set_material import NODE_OT_set_material
+from .nodes.set_world import NODE_OT_set_world
 
 classes = (
     SceneNodeSocket,
+    CollectionNodeSocket,
+    ObjectNodeSocket,
+    CameraNodeSocket,
+    MaterialNodeSocket,
+    WorldNodeSocket,
     SCENE_NODES_TREE,
     NODE_OT_create_scene,
     NODE_OT_render_scene,
+    NODE_OT_add_collection,
+    NODE_OT_set_material,
+    NODE_OT_set_world,
 )
 
 # node categories for the Add menu
@@ -37,6 +56,9 @@ node_categories = [
     SceneNodeCategory('SCENE_NODES', 'Scene Nodes', items=[
         NodeItem(NODE_OT_create_scene.bl_idname),
         NodeItem(NODE_OT_render_scene.bl_idname),
+        NodeItem(NODE_OT_add_collection.bl_idname),
+        NodeItem(NODE_OT_set_material.bl_idname),
+        NodeItem(NODE_OT_set_world.bl_idname),
     ]),
 ]
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -6,6 +6,26 @@ def _new_scene_property():
     """Pointer property for storing a Blender Scene."""
     return bpy.props.PointerProperty(name="Scene", type=bpy.types.Scene)
 
+def _new_collection_property():
+    """Pointer property for storing a Blender Collection."""
+    return bpy.props.PointerProperty(name="Collection", type=bpy.types.Collection)
+
+def _new_object_property():
+    """Pointer property for storing a Blender Object."""
+    return bpy.props.PointerProperty(name="Object", type=bpy.types.Object)
+
+def _new_camera_property():
+    """Pointer property for storing a Blender Camera."""
+    return bpy.props.PointerProperty(name="Camera", type=bpy.types.Camera)
+
+def _new_material_property():
+    """Pointer property for storing a Blender Material."""
+    return bpy.props.PointerProperty(name="Material", type=bpy.types.Material)
+
+def _new_world_property():
+    """Pointer property for storing a Blender World."""
+    return bpy.props.PointerProperty(name="World", type=bpy.types.World)
+
 class SceneNodeSocket(NodeSocket):
     bl_idname = 'SceneNodeSocketType'
     bl_label = 'Scene Socket'
@@ -16,6 +36,92 @@ class SceneNodeSocket(NodeSocket):
 
     def draw_color(self, context, node):
         return (0.6, 0.8, 0.2, 1.0)
+
+
+class CollectionNodeSocket(NodeSocket):
+    bl_idname = 'CollectionNodeSocketType'
+    bl_label = 'Collection Socket'
+    collection: _new_collection_property()
+
+    def draw(self, context, layout, node, text):
+        layout.label(text=text)
+
+    def draw_color(self, context, node):
+        return (0.8, 0.4, 0.1, 1.0)
+
+
+class ObjectNodeSocket(NodeSocket):
+    bl_idname = 'ObjectNodeSocketType'
+    bl_label = 'Object Socket'
+    object: _new_object_property()
+
+    def draw(self, context, layout, node, text):
+        layout.label(text=text)
+
+    def draw_color(self, context, node):
+        return (0.4, 0.6, 0.8, 1.0)
+
+
+class CameraNodeSocket(NodeSocket):
+    bl_idname = 'CameraNodeSocketType'
+    bl_label = 'Camera Socket'
+    camera: _new_camera_property()
+
+    def draw(self, context, layout, node, text):
+        layout.label(text=text)
+
+    def draw_color(self, context, node):
+        return (0.7, 0.7, 0.3, 1.0)
+
+
+class MaterialNodeSocket(NodeSocket):
+    bl_idname = 'MaterialNodeSocketType'
+    bl_label = 'Material Socket'
+    material: _new_material_property()
+
+    def draw(self, context, layout, node, text):
+        layout.label(text=text)
+
+    def draw_color(self, context, node):
+        return (0.9, 0.5, 0.9, 1.0)
+
+
+class WorldNodeSocket(NodeSocket):
+    bl_idname = 'WorldNodeSocketType'
+    bl_label = 'World Socket'
+    world: _new_world_property()
+
+    def draw(self, context, layout, node, text):
+        layout.label(text=text)
+
+    def draw_color(self, context, node):
+        return (0.2, 0.4, 0.8, 1.0)
+
+
+def get_socket_value(socket, attribute):
+    """Retrieve the value from a socket, considering links."""
+    if not socket:
+        return None
+    if socket.is_linked:
+        for link in socket.links:
+            source = link.from_socket
+            value = getattr(source, attribute, None)
+            if value is not None:
+                return value
+    return getattr(socket, attribute, None)
+
+
+def hash_inputs(*values):
+    """Return a combined hash of the given values."""
+    ids = []
+    for val in values:
+        if val is None:
+            ids.append(None)
+        elif hasattr(val, "name"):
+            ids.append(val.name)
+        else:
+            ids.append(val)
+    return hash(tuple(ids))
 
 class SCENE_NODES_TREE(NodeTree):
     bl_idname = 'SCENE_NODES_TREE'

--- a/nodes/add_collection.py
+++ b/nodes/add_collection.py
@@ -1,0 +1,37 @@
+import bpy
+from bpy.types import Node
+
+from ..node_tree import hash_inputs
+
+
+class NODE_OT_add_collection(Node):
+    bl_idname = 'NODE_OT_add_collection'
+    bl_label = 'Add Collection'
+    bl_icon = 'OUTLINER_COLLECTION'
+
+    def init(self, context):
+        self.outputs.new('CollectionNodeSocketType', "Collection")
+
+    def update(self):
+        output = self.outputs.get("Collection")
+        if not output:
+            return
+
+        base_name = "Collection"
+        name = base_name
+        index = 1
+        while name in bpy.data.collections:
+            name = f"{base_name}.{index:03d}"
+            index += 1
+
+        new_col = bpy.data.collections.new(name)
+        output.collection = new_col
+        self.node_hash = hash_inputs(new_col)
+
+
+def register():
+    bpy.utils.register_class(NODE_OT_add_collection)
+
+
+def unregister():
+    bpy.utils.unregister_class(NODE_OT_add_collection)

--- a/nodes/set_material.py
+++ b/nodes/set_material.py
@@ -1,0 +1,35 @@
+import bpy
+from bpy.types import Node
+
+from ..node_tree import hash_inputs, get_socket_value
+
+
+class NODE_OT_set_material(Node):
+    bl_idname = 'NODE_OT_set_material'
+    bl_label = 'Set Material'
+    bl_icon = 'MATERIAL'
+
+    def init(self, context):
+        self.inputs.new('ObjectNodeSocketType', "Object")
+        self.inputs.new('MaterialNodeSocketType', "Material")
+        self.outputs.new('ObjectNodeSocketType', "Object")
+
+    def update(self):
+        obj = get_socket_value(self.inputs.get("Object"), 'object')
+        mat = get_socket_value(self.inputs.get("Material"), 'material')
+        if obj and mat and hasattr(obj.data, 'materials'):
+            if len(obj.data.materials):
+                obj.data.materials[0] = mat
+            else:
+                obj.data.materials.append(mat)
+        if obj:
+            self.outputs["Object"].object = obj
+        self.node_hash = hash_inputs(obj, mat)
+
+
+def register():
+    bpy.utils.register_class(NODE_OT_set_material)
+
+
+def unregister():
+    bpy.utils.unregister_class(NODE_OT_set_material)

--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -1,0 +1,29 @@
+import bpy
+from bpy.types import Node
+
+from ..node_tree import hash_inputs, get_socket_value
+
+
+class NODE_OT_set_world(Node):
+    bl_idname = 'NODE_OT_set_world'
+    bl_label = 'Set World'
+    bl_icon = 'WORLD_DATA'
+
+    def init(self, context):
+        self.inputs.new('SceneNodeSocketType', "Scene")
+        self.inputs.new('WorldNodeSocketType', "World")
+
+    def update(self):
+        scene = get_socket_value(self.inputs.get("Scene"), 'scene')
+        world = get_socket_value(self.inputs.get("World"), 'world')
+        if scene and world:
+            scene.world = world
+        self.node_hash = hash_inputs(scene, world)
+
+
+def register():
+    bpy.utils.register_class(NODE_OT_set_world)
+
+
+def unregister():
+    bpy.utils.unregister_class(NODE_OT_set_world)


### PR DESCRIPTION
## Summary
- extend node sockets to support collections, objects, cameras, materials and worlds
- add Collection, Set Material and Set World nodes with input hashing
- register the new sockets and nodes in the addon

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854f42298a8833084e66f5babd7c2a9