### PR TITLE
Add user edit preservation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,19 @@ Once enabled, open the *Geometry Node Editor* and switch the tree type to **Scen
 - **Render Scene** — takes a scene input and renders it.
 
 These nodes are registered under the *Scene Nodes* category.
+
+## User Edits
+
+Object transforms or other adjustments made manually after evaluating the node tree can be stored so they persist across updates. Use the helper functions in `user_edits.py` to manage these values:
+
+```python
+from .user_edits import record_object_transform, apply_object_transform
+
+# After editing an object
+record_object_transform(obj)
+
+# Before a node overwrites an object transform
+apply_object_transform(obj)
+```
+
+Nodes may call `apply_object_transform` (or the convenience wrapper `apply_user_edits`) when they need to preserve user tweaks while re-evaluating the graph.

--- a/nodes/set_material.py
+++ b/nodes/set_material.py
@@ -2,6 +2,7 @@ import bpy
 from bpy.types import Node
 
 from ..node_tree import hash_inputs, get_socket_value
+from ..user_edits import apply_user_edits
 
 
 class NODE_OT_set_material(Node):
@@ -17,6 +18,8 @@ class NODE_OT_set_material(Node):
     def update(self):
         obj = get_socket_value(self.inputs.get("Object"), 'object')
         mat = get_socket_value(self.inputs.get("Material"), 'material')
+        if obj:
+            apply_user_edits(obj)
         if obj and mat and hasattr(obj.data, 'materials'):
             if len(obj.data.materials):
                 obj.data.materials[0] = mat

--- a/user_edits.py
+++ b/user_edits.py
@@ -1,0 +1,36 @@
+import bpy
+
+# In-memory store for object transform edits made by the user.
+# Keys are Blender object names, values hold location/rotation/scale copies.
+_USER_TRANSFORMS = {}
+
+
+def record_object_transform(obj):
+    """Store the current transform values of ``obj`` for later use."""
+    if obj is None:
+        return
+    _USER_TRANSFORMS[obj.name] = {
+        "location": obj.location.copy(),
+        "rotation_euler": obj.rotation_euler.copy(),
+        "scale": obj.scale.copy(),
+    }
+
+
+def apply_object_transform(obj):
+    """Apply stored transform values back onto ``obj`` if present."""
+    data = _USER_TRANSFORMS.get(obj.name)
+    if not data:
+        return
+    obj.location = data["location"]
+    obj.rotation_euler = data["rotation_euler"]
+    obj.scale = data["scale"]
+
+
+def clear_object_transform(obj):
+    """Remove stored transform data for ``obj`` if it exists."""
+    _USER_TRANSFORMS.pop(obj.name, None)
+
+
+def apply_user_edits(obj):
+    """Convenience wrapper to reapply all known edits for ``obj``."""
+    apply_object_transform(obj)


### PR DESCRIPTION
## Summary
- manage user edits in `user_edits.py`
- document API for preserving edits across node re-evaluation
- apply stored edits when setting materials

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854f534b9ec833081ce5aa53bef9d8f