### PR TITLE
Add node execution operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Once enabled, open the *Geometry Node Editor* and switch the tree type to **Scen
 
 These nodes are registered under the *Scene Nodes* category.
 
+### Manual Execution
+
+Each node header displays a small circle icon. Clicking this icon evaluates the
+graph up to the clicked node using a simple dependency solver. The circle for
+the most recently executed node is filled to indicate the active scene state.
+
 ## User Edits
 
 Object transforms or other adjustments made manually after evaluating the node tree can be stored so they persist across updates. Use the helper functions in `user_edits.py` to manage these values:

--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,7 @@ from .nodes.render_scene import NODE_OT_render_scene
 from .nodes.add_collection import NODE_OT_add_collection
 from .nodes.set_material import NODE_OT_set_material
 from .nodes.set_world import NODE_OT_set_world
+from .executor import SCENE_OT_execute_to_node
 
 classes = (
     SceneNodeSocket,
@@ -44,6 +45,7 @@ classes = (
     NODE_OT_add_collection,
     NODE_OT_set_material,
     NODE_OT_set_world,
+    SCENE_OT_execute_to_node,
 )
 
 # node categories for the Add menu

--- a/executor.py
+++ b/executor.py
@@ -1,0 +1,82 @@
+class NodeExecutor:
+    """Utility class to evaluate Scene Node graphs."""
+    def __init__(self, node_tree):
+        self.node_tree = node_tree
+
+    def _build_graph(self):
+        graph = {node: set() for node in self.node_tree.nodes}
+        for link in self.node_tree.links:
+            graph.setdefault(link.from_node, set()).add(link.to_node)
+            graph.setdefault(link.to_node, set())
+        return graph
+
+    def _topological_order(self):
+        graph = self._build_graph()
+        indegree = {node: 0 for node in graph}
+        for frm, targets in graph.items():
+            for tgt in targets:
+                indegree[tgt] += 1
+        queue = [n for n, d in indegree.items() if d == 0]
+        order = []
+        while queue:
+            node = queue.pop(0)
+            order.append(node)
+            for tgt in graph[node]:
+                indegree[tgt] -= 1
+                if indegree[tgt] == 0:
+                    queue.append(tgt)
+        return order
+
+    def execute_until(self, target_node=None):
+        """Execute nodes in topological order up to ``target_node``."""
+        order = self._topological_order()
+        for node in order:
+            if hasattr(node, 'evaluate'):
+                node.evaluate()
+            elif hasattr(node, 'update'):
+                node.update()
+            if target_node and node == target_node:
+                break
+
+
+import bpy
+from bpy.types import Operator
+
+
+def draw_execute_button(node, layout):
+    """Utility to draw the execution button on nodes."""
+    tree = node.id_data
+    active = getattr(tree, 'active_node_name', '')
+    icon = 'RADIOBUT_ON' if node.name == active else 'RADIOBUT_OFF'
+    op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
+    op.node_name = node.name
+
+
+class SCENE_OT_execute_to_node(Operator):
+    bl_idname = 'scene_nodes.execute_to_node'
+    bl_label = 'Execute Scene Nodes'
+
+    node_name: bpy.props.StringProperty()
+
+    @classmethod
+    def poll(cls, context):
+        return getattr(context.space_data, 'node_tree', None) is not None
+
+    def execute(self, context):
+        tree = context.space_data.node_tree
+        node = tree.nodes.get(self.node_name)
+        if node is None:
+            self.report({'ERROR'}, 'Node not found')
+            return {'CANCELLED'}
+        executor = NodeExecutor(tree)
+        executor.execute_until(node)
+        tree.active_node_name = node.name
+        return {'FINISHED'}
+
+
+def register():
+    bpy.utils.register_class(SCENE_OT_execute_to_node)
+
+
+def unregister():
+    bpy.utils.unregister_class(SCENE_OT_execute_to_node)

--- a/node_tree.py
+++ b/node_tree.py
@@ -128,6 +128,8 @@ class SCENE_NODES_TREE(NodeTree):
     bl_label = 'Scene Nodes'
     bl_icon = 'SCENE_DATA'
 
+    active_node_name: bpy.props.StringProperty(name="Active Node", default="")
+
     @classmethod
     def poll(cls, context):
         return True

--- a/nodes/add_collection.py
+++ b/nodes/add_collection.py
@@ -7,10 +7,14 @@ from ..node_tree import hash_inputs
 class NODE_OT_add_collection(Node):
     bl_idname = 'NODE_OT_add_collection'
     bl_label = 'Add Collection'
-    bl_icon = 'OUTLINER_COLLECTION'
+    bl_icon = 'RADIOBUT_OFF'
 
     def init(self, context):
         self.outputs.new('CollectionNodeSocketType', "Collection")
+
+    def draw_buttons(self, context, layout):
+        from ..executor import draw_execute_button
+        draw_execute_button(self, layout)
 
     def update(self):
         output = self.outputs.get("Collection")

--- a/nodes/create_scene.py
+++ b/nodes/create_scene.py
@@ -6,10 +6,14 @@ from ..node_tree import SceneNodeSocket
 class NODE_OT_create_scene(Node):
     bl_idname = 'NODE_OT_create_scene'
     bl_label = 'Create Scene'
-    bl_icon = 'SCENE_DATA'
+    bl_icon = 'RADIOBUT_OFF'
 
     def init(self, context):
         self.outputs.new('SceneNodeSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        from ..executor import draw_execute_button
+        draw_execute_button(self, layout)
 
     def update(self):
         output = self.outputs.get("Scene")

--- a/nodes/render_scene.py
+++ b/nodes/render_scene.py
@@ -6,10 +6,14 @@ from ..node_tree import SceneNodeSocket
 class NODE_OT_render_scene(Node):
     bl_idname = 'NODE_OT_render_scene'
     bl_label = 'Render Scene'
-    bl_icon = 'RENDER_STILL'
+    bl_icon = 'RADIOBUT_OFF'
 
     def init(self, context):
         self.inputs.new('SceneNodeSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        from ..executor import draw_execute_button
+        draw_execute_button(self, layout)
 
     def update(self):
         input_socket = self.inputs.get("Scene")

--- a/nodes/set_material.py
+++ b/nodes/set_material.py
@@ -8,12 +8,16 @@ from ..user_edits import apply_user_edits
 class NODE_OT_set_material(Node):
     bl_idname = 'NODE_OT_set_material'
     bl_label = 'Set Material'
-    bl_icon = 'MATERIAL'
+    bl_icon = 'RADIOBUT_OFF'
 
     def init(self, context):
         self.inputs.new('ObjectNodeSocketType', "Object")
         self.inputs.new('MaterialNodeSocketType', "Material")
         self.outputs.new('ObjectNodeSocketType', "Object")
+
+    def draw_buttons(self, context, layout):
+        from ..executor import draw_execute_button
+        draw_execute_button(self, layout)
 
     def update(self):
         obj = get_socket_value(self.inputs.get("Object"), 'object')

--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -7,11 +7,15 @@ from ..node_tree import hash_inputs, get_socket_value
 class NODE_OT_set_world(Node):
     bl_idname = 'NODE_OT_set_world'
     bl_label = 'Set World'
-    bl_icon = 'WORLD_DATA'
+    bl_icon = 'RADIOBUT_OFF'
 
     def init(self, context):
         self.inputs.new('SceneNodeSocketType', "Scene")
         self.inputs.new('WorldNodeSocketType', "World")
+
+    def draw_buttons(self, context, layout):
+        from ..executor import draw_execute_button
+        draw_execute_button(self, layout)
 
     def update(self):
         scene = get_socket_value(self.inputs.get("Scene"), 'scene')


### PR DESCRIPTION
## Summary
- implement NodeExecutor for building a dependency graph and executing nodes
- add `scene_nodes.execute_to_node` operator and execution button for nodes
- use circle icons for nodes and show active node filled
- register operator and document usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68550178db9083308c756ea469b01249