### PR TITLE
Add automatic recording of user object transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ apply_object_transform(obj)
 ```
 
 Nodes may call `apply_object_transform` (or the convenience wrapper `apply_user_edits`) when they need to preserve user tweaks while re-evaluating the graph.
+
+The addon also registers a handler on Blender's dependency graph updates that automatically calls `record_object_transform` whenever an object is moved, rotated or scaled. Transform values are stored for each node so manual adjustments persist across evaluations.

--- a/__init__.py
+++ b/__init__.py
@@ -31,6 +31,7 @@ from .nodes.add_collection import NODE_OT_add_collection
 from .nodes.set_material import NODE_OT_set_material
 from .nodes.set_world import NODE_OT_set_world
 from .executor import SCENE_OT_execute_to_node
+from .handlers import register_handlers, unregister_handlers
 
 classes = (
     SceneNodeSocket,
@@ -69,8 +70,10 @@ def register():
         bpy.utils.register_class(cls)
     bpy.types.Scene.scene_nodes_tree = bpy.props.PointerProperty(type=SCENE_NODES_TREE)
     register_node_categories('SCENE_NODES', node_categories)
+    register_handlers()
 
 def unregister():
+    unregister_handlers()
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
     del bpy.types.Scene.scene_nodes_tree

--- a/handlers.py
+++ b/handlers.py
@@ -1,0 +1,34 @@
+import bpy
+from bpy.app.handlers import persistent
+from .user_edits import record_object_transform
+
+_LAST_TRANSFORMS = {}
+
+def _transform_state(obj):
+    return (
+        tuple(obj.location),
+        tuple(obj.rotation_euler),
+        tuple(obj.scale),
+    )
+
+@persistent
+def record_transforms(scene, depsgraph):
+    """Record object transform changes after depsgraph updates."""
+    for update in depsgraph.updates:
+        id_ = update.id
+        if isinstance(id_, bpy.types.Object):
+            obj = id_
+            current = _transform_state(obj)
+            prev = _LAST_TRANSFORMS.get(obj.name)
+            if prev != current:
+                record_object_transform(obj)
+                _LAST_TRANSFORMS[obj.name] = current
+
+def register_handlers():
+    if record_transforms not in bpy.app.handlers.depsgraph_update_post:
+        bpy.app.handlers.depsgraph_update_post.append(record_transforms)
+
+def unregister_handlers():
+    if record_transforms in bpy.app.handlers.depsgraph_update_post:
+        bpy.app.handlers.depsgraph_update_post.remove(record_transforms)
+    _LAST_TRANSFORMS.clear()


### PR DESCRIPTION
## Summary
- automatically record object transform changes via a depsgraph handler
- hook handler registration into addon setup
- document automatic recording in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855041fe4bc8330ad2996da6d72efcb