### PR TITLE
Improve Scene node controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ These nodes are registered under the *Scene Nodes* category.
 
 ### Manual Execution
 
-Each node header displays a small circle icon. Clicking this icon evaluates the
-graph up to the clicked node using a simple dependency solver. The circle for
-the most recently executed node is filled to indicate the active scene state.
+Only nodes that operate on scenes display a small circle icon in their header.
+Clicking this icon evaluates the graph up to the clicked node using a simple
+dependency solver. The circle for the most recently executed node is filled to
+indicate the active scene state.
 
 ## User Edits
 

--- a/executor.py
+++ b/executor.py
@@ -48,7 +48,9 @@ def draw_execute_button(node, layout):
     tree = node.id_data
     active = getattr(tree, 'active_node_name', '')
     icon = 'RADIOBUT_ON' if node.name == active else 'RADIOBUT_OFF'
-    op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
+    row = layout.row(align=True)
+    row.alignment = 'RIGHT'
+    op = row.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
     op.node_name = node.name
 
 

--- a/nodes/add_collection.py
+++ b/nodes/add_collection.py
@@ -12,10 +12,6 @@ class NODE_OT_add_collection(Node):
     def init(self, context):
         self.outputs.new('CollectionNodeSocketType', "Collection")
 
-    def draw_buttons(self, context, layout):
-        from ..executor import draw_execute_button
-        draw_execute_button(self, layout)
-
     def update(self):
         output = self.outputs.get("Collection")
         if not output:

--- a/nodes/set_material.py
+++ b/nodes/set_material.py
@@ -15,10 +15,6 @@ class NODE_OT_set_material(Node):
         self.inputs.new('MaterialNodeSocketType', "Material")
         self.outputs.new('ObjectNodeSocketType', "Object")
 
-    def draw_buttons(self, context, layout):
-        from ..executor import draw_execute_button
-        draw_execute_button(self, layout)
-
     def update(self):
         obj = get_socket_value(self.inputs.get("Object"), 'object')
         mat = get_socket_value(self.inputs.get("Material"), 'material')

--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -12,6 +12,7 @@ class NODE_OT_set_world(Node):
     def init(self, context):
         self.inputs.new('SceneNodeSocketType', "Scene")
         self.inputs.new('WorldNodeSocketType', "World")
+        self.outputs.new('SceneNodeSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
         from ..executor import draw_execute_button
@@ -22,6 +23,8 @@ class NODE_OT_set_world(Node):
         world = get_socket_value(self.inputs.get("World"), 'world')
         if scene and world:
             scene.world = world
+        if scene:
+            self.outputs["Scene"].scene = scene
         self.node_hash = hash_inputs(scene, world)
 
 


### PR DESCRIPTION
## Summary
- show execute button only for nodes dealing with scenes
- align execute button to node header corner
- add Scene output to Set World node
- document that only scene nodes expose the manual execute icon

## Testing
- `python -m compileall -q .`
- `python -m flake8 .` *(fails: E/F/W errors)*

------
https://chatgpt.com/codex/tasks/task_e_685505f9e3688330beedc6e639f6119a