### PR TITLE
Implement dynamic scene and add input nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,13 @@ This is a simple example addon that demonstrates a basic node tree for procedura
 
 Once enabled, open the *Geometry Node Editor* and switch the tree type to **Scene Nodes**. Use the **Add** menu to access the custom nodes:
 
-- **Create Scene** — outputs a new scene.
+- **Create Scene** — outputs a dynamic scene reused across executions.
 - **Render Scene** — takes a scene input and renders it.
+- **Add Collection** — creates a new collection datablock.
+- **Set Material** — assign a material to an object.
+- **Set World** — assign a world to a scene.
+- **Read Blend File** — load datablock names from an external blend file.
+- **Input Nodes** — provide basic values (String, Bool, Float, Integer, Vector, Object, Material, World).
 
 These nodes are registered under the *Scene Nodes* category.
 

--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,15 @@ from .nodes.render_scene import NODE_OT_render_scene
 from .nodes.add_collection import NODE_OT_add_collection
 from .nodes.set_material import NODE_OT_set_material
 from .nodes.set_world import NODE_OT_set_world
+from .nodes.input_string import NODE_OT_input_string
+from .nodes.input_bool import NODE_OT_input_bool
+from .nodes.input_float import NODE_OT_input_float
+from .nodes.input_integer import NODE_OT_input_integer
+from .nodes.input_vector import NODE_OT_input_vector
+from .nodes.input_material import NODE_OT_input_material
+from .nodes.input_world import NODE_OT_input_world
+from .nodes.input_object import NODE_OT_input_object
+from .nodes.read_blend_file import NODE_OT_read_blend_file
 from .executor import SCENE_OT_execute_to_node
 from .handlers import register_handlers, unregister_handlers
 
@@ -46,6 +55,15 @@ classes = (
     NODE_OT_add_collection,
     NODE_OT_set_material,
     NODE_OT_set_world,
+    NODE_OT_input_string,
+    NODE_OT_input_bool,
+    NODE_OT_input_float,
+    NODE_OT_input_integer,
+    NODE_OT_input_vector,
+    NODE_OT_input_material,
+    NODE_OT_input_world,
+    NODE_OT_input_object,
+    NODE_OT_read_blend_file,
     SCENE_OT_execute_to_node,
 )
 
@@ -62,6 +80,15 @@ node_categories = [
         NodeItem(NODE_OT_add_collection.bl_idname),
         NodeItem(NODE_OT_set_material.bl_idname),
         NodeItem(NODE_OT_set_world.bl_idname),
+        NodeItem(NODE_OT_input_string.bl_idname),
+        NodeItem(NODE_OT_input_bool.bl_idname),
+        NodeItem(NODE_OT_input_float.bl_idname),
+        NodeItem(NODE_OT_input_integer.bl_idname),
+        NodeItem(NODE_OT_input_vector.bl_idname),
+        NodeItem(NODE_OT_input_material.bl_idname),
+        NodeItem(NODE_OT_input_world.bl_idname),
+        NodeItem(NODE_OT_input_object.bl_idname),
+        NodeItem(NODE_OT_read_blend_file.bl_idname),
     ]),
 ]
 

--- a/executor.py
+++ b/executor.py
@@ -43,15 +43,11 @@ import bpy
 from bpy.types import Operator
 
 
-def draw_execute_button(node, layout):
-    """Utility to draw the execution button on nodes."""
-    tree = node.id_data
+def update_node_icons(tree):
+    """Update header icons on all nodes to reflect execution state."""
     active = getattr(tree, 'active_node_name', '')
-    icon = 'RADIOBUT_ON' if node.name == active else 'RADIOBUT_OFF'
-    row = layout.row(align=True)
-    row.alignment = 'RIGHT'
-    op = row.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
-    op.node_name = node.name
+    for node in tree.nodes:
+        node.bl_icon = 'RADIOBUT_ON' if node.name == active else 'RADIOBUT_OFF'
 
 
 class SCENE_OT_execute_to_node(Operator):
@@ -73,6 +69,7 @@ class SCENE_OT_execute_to_node(Operator):
         executor = NodeExecutor(tree)
         executor.execute_until(node)
         tree.active_node_name = node.name
+        update_node_icons(tree)
         return {'FINISHED'}
 
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -129,6 +129,7 @@ class SCENE_NODES_TREE(NodeTree):
     bl_icon = 'SCENE_DATA'
 
     active_node_name: bpy.props.StringProperty(name="Active Node", default="")
+    dynamic_scene: _new_scene_property()
 
     @classmethod
     def poll(cls, context):

--- a/nodes/create_scene.py
+++ b/nodes/create_scene.py
@@ -11,26 +11,27 @@ class NODE_OT_create_scene(Node):
     def init(self, context):
         self.outputs.new('SceneNodeSocketType', "Scene")
 
-    def draw_buttons(self, context, layout):
-        from ..executor import draw_execute_button
-        draw_execute_button(self, layout)
+
 
     def update(self):
         output = self.outputs.get("Scene")
         if not output:
             return
 
-        base_name = "Scene"
-        name = base_name
-        index = 1
-        # ensure unique scene name
-        while name in bpy.data.scenes:
-            name = f"{base_name}.{index:03d}"
-            index += 1
+        tree = self.id_data
+        scene = getattr(tree, "dynamic_scene", None)
 
-        new_scene = bpy.data.scenes.new(name)
-        # store the created scene on the socket so it can be passed to other nodes
-        output.scene = new_scene
+        if scene is None or scene.name not in bpy.data.scenes:
+            base_name = "Scene"
+            name = base_name
+            index = 1
+            while name in bpy.data.scenes:
+                name = f"{base_name}.{index:03d}"
+                index += 1
+            scene = bpy.data.scenes.new(name)
+            tree.dynamic_scene = scene
+
+        output.scene = scene
 
 def register():
     bpy.utils.register_class(NODE_OT_create_scene)

--- a/nodes/input_bool.py
+++ b/nodes/input_bool.py
@@ -1,0 +1,20 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_input_bool(Node):
+    bl_idname = 'NODE_OT_input_bool'
+    bl_label = 'Boolean Input'
+    bl_icon = 'CHECKBOX_HLT'
+
+    value: bpy.props.BoolProperty(name="Value")
+
+    def init(self, context):
+        self.outputs.new('NodeSocketBool', "Boolean")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'value', text="")
+
+    def update(self):
+        if self.outputs:
+            self.outputs[0].default_value = self.value

--- a/nodes/input_float.py
+++ b/nodes/input_float.py
@@ -1,0 +1,20 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_input_float(Node):
+    bl_idname = 'NODE_OT_input_float'
+    bl_label = 'Float Input'
+    bl_icon = 'LINENUMBERS_ON'
+
+    value: bpy.props.FloatProperty(name="Value")
+
+    def init(self, context):
+        self.outputs.new('NodeSocketFloat', "Float")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'value', text="")
+
+    def update(self):
+        if self.outputs:
+            self.outputs[0].default_value = self.value

--- a/nodes/input_integer.py
+++ b/nodes/input_integer.py
@@ -1,0 +1,20 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_input_integer(Node):
+    bl_idname = 'NODE_OT_input_integer'
+    bl_label = 'Integer Input'
+    bl_icon = 'LINENUMBERS_ON'
+
+    value: bpy.props.IntProperty(name="Value")
+
+    def init(self, context):
+        self.outputs.new('NodeSocketInt', "Integer")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'value', text="")
+
+    def update(self):
+        if self.outputs:
+            self.outputs[0].default_value = self.value

--- a/nodes/input_material.py
+++ b/nodes/input_material.py
@@ -1,0 +1,20 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_input_material(Node):
+    bl_idname = 'NODE_OT_input_material'
+    bl_label = 'Material Input'
+    bl_icon = 'MATERIAL'
+
+    material: bpy.props.PointerProperty(type=bpy.types.Material)
+
+    def init(self, context):
+        self.outputs.new('MaterialNodeSocketType', "Material")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'material')
+
+    def update(self):
+        if self.outputs and self.material:
+            self.outputs[0].material = self.material

--- a/nodes/input_object.py
+++ b/nodes/input_object.py
@@ -1,0 +1,20 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_input_object(Node):
+    bl_idname = 'NODE_OT_input_object'
+    bl_label = 'Object Input'
+    bl_icon = 'OBJECT_DATA'
+
+    object: bpy.props.PointerProperty(type=bpy.types.Object)
+
+    def init(self, context):
+        self.outputs.new('ObjectNodeSocketType', "Object")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'object')
+
+    def update(self):
+        if self.outputs and self.object:
+            self.outputs[0].object = self.object

--- a/nodes/input_string.py
+++ b/nodes/input_string.py
@@ -1,0 +1,20 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_input_string(Node):
+    bl_idname = 'NODE_OT_input_string'
+    bl_label = 'String Input'
+    bl_icon = 'SORTALPHA'
+
+    value: bpy.props.StringProperty(name="Value")
+
+    def init(self, context):
+        self.outputs.new('NodeSocketString', "String")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'value', text="")
+
+    def update(self):
+        if self.outputs:
+            self.outputs[0].default_value = self.value

--- a/nodes/input_vector.py
+++ b/nodes/input_vector.py
@@ -1,0 +1,20 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_input_vector(Node):
+    bl_idname = 'NODE_OT_input_vector'
+    bl_label = 'Vector Input'
+    bl_icon = 'EMPTY_ARROWS'
+
+    value: bpy.props.FloatVectorProperty(name="Value")
+
+    def init(self, context):
+        self.outputs.new('NodeSocketVector', "Vector")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'value', text="")
+
+    def update(self):
+        if self.outputs:
+            self.outputs[0].default_value = self.value

--- a/nodes/input_world.py
+++ b/nodes/input_world.py
@@ -1,0 +1,20 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_input_world(Node):
+    bl_idname = 'NODE_OT_input_world'
+    bl_label = 'World Input'
+    bl_icon = 'WORLD'
+
+    world: bpy.props.PointerProperty(type=bpy.types.World)
+
+    def init(self, context):
+        self.outputs.new('WorldNodeSocketType', "World")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'world')
+
+    def update(self):
+        if self.outputs and self.world:
+            self.outputs[0].world = self.world

--- a/nodes/read_blend_file.py
+++ b/nodes/read_blend_file.py
@@ -1,0 +1,36 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_read_blend_file(Node):
+    bl_idname = 'NODE_OT_read_blend_file'
+    bl_label = 'Read Blend File'
+    bl_icon = 'FILE_FOLDER'
+
+    filepath: bpy.props.StringProperty(name="File Path", subtype='FILE_PATH')
+
+    def init(self, context):
+        self.outputs.new('NodeSocketString', 'Scenes')
+        self.outputs.new('NodeSocketString', 'Objects')
+        self.outputs.new('NodeSocketString', 'Materials')
+        self.outputs.new('NodeSocketString', 'Worlds')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'filepath', text="")
+
+    def update(self):
+        if not self.filepath:
+            return
+        try:
+            with bpy.data.libraries.load(self.filepath, link=False) as (data_from, _):
+                scenes = ';'.join(data_from.scenes)
+                objects = ';'.join(data_from.objects)
+                materials = ';'.join(data_from.materials)
+                worlds = ';'.join(data_from.worlds)
+        except Exception:
+            scenes = objects = materials = worlds = ''
+        if self.outputs:
+            self.outputs['Scenes'].default_value = scenes
+            self.outputs['Objects'].default_value = objects
+            self.outputs['Materials'].default_value = materials
+            self.outputs['Worlds'].default_value = worlds

--- a/nodes/render_scene.py
+++ b/nodes/render_scene.py
@@ -11,9 +11,7 @@ class NODE_OT_render_scene(Node):
     def init(self, context):
         self.inputs.new('SceneNodeSocketType', "Scene")
 
-    def draw_buttons(self, context, layout):
-        from ..executor import draw_execute_button
-        draw_execute_button(self, layout)
+
 
     def update(self):
         input_socket = self.inputs.get("Scene")

--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -14,9 +14,7 @@ class NODE_OT_set_world(Node):
         self.inputs.new('WorldNodeSocketType', "World")
         self.outputs.new('SceneNodeSocketType', "Scene")
 
-    def draw_buttons(self, context, layout):
-        from ..executor import draw_execute_button
-        draw_execute_button(self, layout)
+
 
     def update(self):
         scene = get_socket_value(self.inputs.get("Scene"), 'scene')


### PR DESCRIPTION
## Summary
- cache created scene so it isn't duplicated for every evaluation
- sync node header icons when a node is executed
- remove old execute button logic from nodes
- add various input nodes and a node to read datablocks from a blend file
- document the new nodes and dynamic scene behaviour

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855092e581883309f9df130bbd41ea1