### PR TITLE
Improve list nodes to handle datablocks

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,7 @@ from .node_tree import (
     CameraNodeSocket,
     MaterialNodeSocket,
     WorldNodeSocket,
+    ListNodeSocket,
     SCENE_NODES_TREE,
 )
 from .nodes.create_scene import NODE_OT_create_scene
@@ -52,6 +53,7 @@ classes = (
     CameraNodeSocket,
     MaterialNodeSocket,
     WorldNodeSocket,
+    ListNodeSocket,
     SCENE_NODES_TREE,
     NODE_OT_create_scene,
     NODE_OT_render_scene,

--- a/node_tree.py
+++ b/node_tree.py
@@ -98,6 +98,19 @@ class WorldNodeSocket(NodeSocket):
         return (0.2, 0.4, 0.8, 1.0)
 
 
+class ListNodeSocket(NodeSocket):
+    """Socket to pass around lists of datablocks."""
+    bl_idname = 'ListNodeSocketType'
+    bl_label = 'List Socket'
+    items_type: bpy.props.StringProperty(name="Items Type", default="")
+
+    def draw(self, context, layout, node, text):
+        layout.label(text=text)
+
+    def draw_color(self, context, node):
+        return (0.8, 0.8, 0.1, 1.0)
+
+
 def get_socket_value(socket, attribute):
     """Retrieve the value from a socket, considering links."""
     if not socket:

--- a/nodes/list_find.py
+++ b/nodes/list_find.py
@@ -8,24 +8,29 @@ class NODE_OT_list_find(Node):
     bl_icon = 'VIEWZOOM'
 
     def init(self, context):
-        self.inputs.new('NodeSocketString', 'List')
+        self.inputs.new('ListNodeSocketType', 'List')
         self.inputs.new('NodeSocketString', 'Name')
-        self.outputs.new('NodeSocketString', 'Item')
+        self.outputs.new('SceneNodeSocketType', 'Scene')
+        self.outputs.new('ObjectNodeSocketType', 'Object')
+        self.outputs.new('MaterialNodeSocketType', 'Material')
+        self.outputs.new('WorldNodeSocketType', 'World')
         self.outputs.new('NodeSocketInt', 'Index')
 
     def update(self):
-        list_str = get_socket_value(self.inputs.get('List'), 'default_value') or ''
+        items = get_socket_value(self.inputs.get('List'), 'items') or []
+        item_type = getattr(self.inputs.get('List'), 'items_type', '')
         name = get_socket_value(self.inputs.get('Name'), 'default_value') or ''
-        items = [it for it in list_str.split(';') if it]
         idx = -1
-        item = ''
+        item = None
         if name:
-            try:
-                idx = items.index(name)
-                item = items[idx]
-            except ValueError:
-                idx = -1
-                item = ''
+            for i, it in enumerate(items):
+                if getattr(it, 'name', '') == name:
+                    idx = i
+                    item = it
+                    break
         if self.outputs:
-            self.outputs['Item'].default_value = item
+            self.outputs['Scene'].scene = item if item_type == 'SCENE' else None
+            self.outputs['Object'].object = item if item_type == 'OBJECT' else None
+            self.outputs['Material'].material = item if item_type == 'MATERIAL' else None
+            self.outputs['World'].world = item if item_type == 'WORLD' else None
             self.outputs['Index'].default_value = idx

--- a/nodes/list_index.py
+++ b/nodes/list_index.py
@@ -8,18 +8,24 @@ class NODE_OT_list_index(Node):
     bl_icon = 'LINENUMBERS_ON'
 
     def init(self, context):
-        self.inputs.new('NodeSocketString', 'List')
+        self.inputs.new('ListNodeSocketType', 'List')
         self.inputs.new('NodeSocketInt', 'Index')
-        self.outputs.new('NodeSocketString', 'Item')
+        self.outputs.new('SceneNodeSocketType', 'Scene')
+        self.outputs.new('ObjectNodeSocketType', 'Object')
+        self.outputs.new('MaterialNodeSocketType', 'Material')
+        self.outputs.new('WorldNodeSocketType', 'World')
 
     def update(self):
-        list_str = get_socket_value(self.inputs.get('List'), 'default_value') or ''
+        items = get_socket_value(self.inputs.get('List'), 'items') or []
+        item_type = getattr(self.inputs.get('List'), 'items_type', '')
         index = get_socket_value(self.inputs.get('Index'), 'default_value')
         try:
             idx = int(index)
         except (TypeError, ValueError):
             idx = -1
-        items = [it for it in list_str.split(';') if it]
-        item = items[idx] if 0 <= idx < len(items) else ''
+        item = items[idx] if 0 <= idx < len(items) else None
         if self.outputs:
-            self.outputs['Item'].default_value = item
+            self.outputs['Scene'].scene = item if item_type == 'SCENE' else None
+            self.outputs['Object'].object = item if item_type == 'OBJECT' else None
+            self.outputs['Material'].material = item if item_type == 'MATERIAL' else None
+            self.outputs['World'].world = item if item_type == 'WORLD' else None

--- a/nodes/list_length.py
+++ b/nodes/list_length.py
@@ -8,11 +8,11 @@ class NODE_OT_list_length(Node):
     bl_icon = 'ALIGN_JUSTIFY'
 
     def init(self, context):
-        self.inputs.new('NodeSocketString', 'List')
+        self.inputs.new('ListNodeSocketType', 'List')
         self.outputs.new('NodeSocketInt', 'Length')
 
     def update(self):
-        list_str = get_socket_value(self.inputs.get('List'), 'default_value') or ''
-        length = len([it for it in list_str.split(';') if it])
+        items = get_socket_value(self.inputs.get('List'), 'items') or []
+        length = len(items)
         if self.outputs:
             self.outputs['Length'].default_value = length

--- a/nodes/read_blend_file.py
+++ b/nodes/read_blend_file.py
@@ -11,10 +11,10 @@ class NODE_OT_read_blend_file(Node):
 
     def init(self, context):
         self.inputs.new('NodeSocketString', 'File Path')
-        self.outputs.new('NodeSocketString', 'Scenes')
-        self.outputs.new('NodeSocketString', 'Objects')
-        self.outputs.new('NodeSocketString', 'Materials')
-        self.outputs.new('NodeSocketString', 'Worlds')
+        self.outputs.new('ListNodeSocketType', 'Scenes')
+        self.outputs.new('ListNodeSocketType', 'Objects')
+        self.outputs.new('ListNodeSocketType', 'Materials')
+        self.outputs.new('ListNodeSocketType', 'Worlds')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'filepath', text="")
@@ -36,15 +36,24 @@ class NODE_OT_read_blend_file(Node):
         if not path:
             return
         try:
-            with bpy.data.libraries.load(path, link=False) as (data_from, _):
-                scenes = ';'.join(data_from.scenes)
-                objects = ';'.join(data_from.objects)
-                materials = ';'.join(data_from.materials)
-                worlds = ';'.join(data_from.worlds)
+            with bpy.data.libraries.load(path, link=False) as (data_from, data_to):
+                data_to.scenes = list(data_from.scenes)
+                data_to.objects = list(data_from.objects)
+                data_to.materials = list(data_from.materials)
+                data_to.worlds = list(data_from.worlds)
+            scenes = list(data_to.scenes)
+            objects = list(data_to.objects)
+            materials = list(data_to.materials)
+            worlds = list(data_to.worlds)
         except Exception:
-            scenes = objects = materials = worlds = ''
+            scenes = objects = materials = worlds = []
         if self.outputs:
-            self.outputs['Scenes'].default_value = scenes
-            self.outputs['Objects'].default_value = objects
-            self.outputs['Materials'].default_value = materials
-            self.outputs['Worlds'].default_value = worlds
+            out = self.outputs
+            out['Scenes'].items = scenes
+            out['Scenes'].items_type = 'SCENE'
+            out['Objects'].items = objects
+            out['Objects'].items_type = 'OBJECT'
+            out['Materials'].items = materials
+            out['Materials'].items_type = 'MATERIAL'
+            out['Worlds'].items = worlds
+            out['Worlds'].items_type = 'WORLD'


### PR DESCRIPTION
## Summary
- add ListNodeSocket for datablock lists
- update `Read Blend File` node to output actual datablocks
- update list nodes to work with datablock lists

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685512610ee08330856ad997185468ad