### PR TITLE
Update list socket appearance

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -104,11 +104,22 @@ class ListNodeSocket(NodeSocket):
     bl_label = 'List Socket'
     items_type: bpy.props.StringProperty(name="Items Type", default="")
 
+    def __init__(self):
+        # visually differentiate list sockets from single datablock sockets
+        self.display_shape = 'SQUARE'
+
     def draw(self, context, layout, node, text):
         layout.label(text=text)
 
     def draw_color(self, context, node):
-        return (0.8, 0.8, 0.1, 1.0)
+        colors = {
+            'SCENE': (0.6, 0.8, 0.2, 1.0),
+            'OBJECT': (0.4, 0.6, 0.8, 1.0),
+            'MATERIAL': (0.9, 0.5, 0.9, 1.0),
+            'WORLD': (0.2, 0.4, 0.8, 1.0),
+            'COLLECTION': (0.8, 0.4, 0.1, 1.0),
+        }
+        return colors.get(self.items_type, (0.8, 0.8, 0.1, 1.0))
 
 
 def get_socket_value(socket, attribute):

--- a/nodes/read_blend_file.py
+++ b/nodes/read_blend_file.py
@@ -11,10 +11,10 @@ class NODE_OT_read_blend_file(Node):
 
     def init(self, context):
         self.inputs.new('NodeSocketString', 'File Path')
-        self.outputs.new('ListNodeSocketType', 'Scenes')
-        self.outputs.new('ListNodeSocketType', 'Objects')
-        self.outputs.new('ListNodeSocketType', 'Materials')
-        self.outputs.new('ListNodeSocketType', 'Worlds')
+        self.outputs.new('ListNodeSocketType', 'Scenes').display_shape = 'SQUARE'
+        self.outputs.new('ListNodeSocketType', 'Objects').display_shape = 'SQUARE'
+        self.outputs.new('ListNodeSocketType', 'Materials').display_shape = 'SQUARE'
+        self.outputs.new('ListNodeSocketType', 'Worlds').display_shape = 'SQUARE'
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'filepath', text="")


### PR DESCRIPTION
## Summary
- adjust list socket color based on contained datablock type
- use square socket shapes for datablock lists

## Testing
- `python3 -m py_compile __init__.py node_tree.py nodes/*.py handlers.py executor.py user_edits.py`

------
https://chatgpt.com/codex/tasks/task_e_68552ec9f1b48330a3824daad16bb968