### PR TITLE
Ensure ListNodeSocket resets items on creation

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -105,6 +105,8 @@ class ListNodeSocket(NodeSocket):
     items_type: bpy.props.StringProperty(name="Items Type", default="")
 
     def __init__(self):
+        # start with a fresh list so references don't persist across updates
+        self.items = []
         # visually differentiate list sockets from single datablock sockets
         self.display_shape = 'SQUARE'
 

--- a/nodes/list_find.py
+++ b/nodes/list_find.py
@@ -17,8 +17,9 @@ class NODE_OT_list_find(Node):
         self.outputs.new('NodeSocketInt', 'Index')
 
     def update(self):
-        items = get_socket_value(self.inputs.get('List'), 'items') or []
-        item_type = getattr(self.inputs.get('List'), 'items_type', '')
+        list_socket = self.inputs.get('List')
+        items = get_socket_value(list_socket, 'items')
+        item_type = getattr(list_socket, 'items_type', '')
         name = get_socket_value(self.inputs.get('Name'), 'default_value') or ''
         idx = -1
         item = None

--- a/nodes/list_index.py
+++ b/nodes/list_index.py
@@ -16,8 +16,9 @@ class NODE_OT_list_index(Node):
         self.outputs.new('WorldNodeSocketType', 'World')
 
     def update(self):
-        items = get_socket_value(self.inputs.get('List'), 'items') or []
-        item_type = getattr(self.inputs.get('List'), 'items_type', '')
+        list_socket = self.inputs.get('List')
+        items = get_socket_value(list_socket, 'items')
+        item_type = getattr(list_socket, 'items_type', '')
         index = get_socket_value(self.inputs.get('Index'), 'default_value')
         try:
             idx = int(index)

--- a/nodes/list_length.py
+++ b/nodes/list_length.py
@@ -12,7 +12,7 @@ class NODE_OT_list_length(Node):
         self.outputs.new('NodeSocketInt', 'Length')
 
     def update(self):
-        items = get_socket_value(self.inputs.get('List'), 'items') or []
+        items = get_socket_value(self.inputs.get('List'), 'items')
         length = len(items)
         if self.outputs:
             self.outputs['Length'].default_value = length


### PR DESCRIPTION
## Summary
- initialize `ListNodeSocket.items` with an empty list
- update list nodes to read the socket directly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685548371f048330a0b9001663d02407