### PR TITLE
Remove node submodule registration

### DIFF
--- a/nodes/add_collection.py
+++ b/nodes/add_collection.py
@@ -28,10 +28,3 @@ class NODE_OT_add_collection(Node):
         output.collection = new_col
         self.node_hash = hash_inputs(new_col)
 
-
-def register():
-    bpy.utils.register_class(NODE_OT_add_collection)
-
-
-def unregister():
-    bpy.utils.unregister_class(NODE_OT_add_collection)

--- a/nodes/create_scene.py
+++ b/nodes/create_scene.py
@@ -56,9 +56,3 @@ class NODE_OT_create_scene(Node):
                 scene.name = name
 
         output.scene = scene
-
-def register():
-    bpy.utils.register_class(NODE_OT_create_scene)
-
-def unregister():
-    bpy.utils.unregister_class(NODE_OT_create_scene)

--- a/nodes/render_scene.py
+++ b/nodes/render_scene.py
@@ -42,9 +42,3 @@ class NODE_OT_render_scene(Node):
             bpy.ops.render.render()
         finally:
             window.scene = current_scene
-
-def register():
-    bpy.utils.register_class(NODE_OT_render_scene)
-
-def unregister():
-    bpy.utils.unregister_class(NODE_OT_render_scene)

--- a/nodes/set_material.py
+++ b/nodes/set_material.py
@@ -29,10 +29,3 @@ class NODE_OT_set_material(Node):
             self.outputs["Object"].object = obj
         self.node_hash = hash_inputs(obj, mat)
 
-
-def register():
-    bpy.utils.register_class(NODE_OT_set_material)
-
-
-def unregister():
-    bpy.utils.unregister_class(NODE_OT_set_material)

--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -25,10 +25,3 @@ class NODE_OT_set_world(Node):
             self.outputs["Scene"].scene = scene
         self.node_hash = hash_inputs(scene, world)
 
-
-def register():
-    bpy.utils.register_class(NODE_OT_set_world)
-
-
-def unregister():
-    bpy.utils.unregister_class(NODE_OT_set_world)


### PR DESCRIPTION
## Summary
- remove redundant register/unregister calls from several node modules
- keep registration centralized in `__init__.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- run addon register/unregister with mocked `bpy` and `nodeitems_utils`

------
https://chatgpt.com/codex/tasks/task_e_6855ba88b8a88330aaaa3ccdde88fbd1