### PR TITLE
Improve Add Collection node caching

### DIFF
--- a/nodes/add_collection.py
+++ b/nodes/add_collection.py
@@ -9,6 +9,8 @@ class NODE_OT_add_collection(Node):
     bl_label = 'Add Collection'
     bl_icon = 'RADIOBUT_OFF'
 
+    collection: bpy.props.PointerProperty(type=bpy.types.Collection)
+
     def init(self, context):
         self.outputs.new('CollectionNodeSocketType', "Collection")
 
@@ -18,15 +20,33 @@ class NODE_OT_add_collection(Node):
             return
 
         base_name = "Collection"
-        name = base_name
-        index = 1
-        while name in bpy.data.collections:
-            name = f"{base_name}.{index:03d}"
-            index += 1
+        col = getattr(self, "collection", None)
 
-        new_col = bpy.data.collections.new(name)
-        output.collection = new_col
-        self.node_hash = hash_inputs(new_col)
+        if col is None or col.name not in bpy.data.collections:
+            name = base_name
+            index = 1
+            while name in bpy.data.collections:
+                name = f"{base_name}.{index:03d}"
+                index += 1
+            col = bpy.data.collections.new(name)
+            self.collection = col
+        else:
+            if col.name != base_name and base_name not in bpy.data.collections:
+                col.name = base_name
+
+        output.collection = col
+        self.node_hash = hash_inputs(col)
+
+    def free(self):
+        """Remove the stored collection when the node is deleted."""
+        col = getattr(self, "collection", None)
+        if col and col.name in bpy.data.collections:
+            try:
+                if col.users == 0:
+                    bpy.data.collections.remove(col)
+            except Exception:
+                pass
+        self.collection = None
 
 
 def register():


### PR DESCRIPTION
## Summary
- reuse existing collections in Add Collection node
- store the created collection on the node
- remove collection when node gets deleted

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855bac3a67c83309200d3a04e3f464d