### PR TITLE
Fix list socket item handling

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -129,9 +129,12 @@ def get_socket_value(socket, attribute):
         for link in socket.links:
             source = link.from_socket
             value = getattr(source, attribute, None)
-            if value is not None:
+            if value is not None and not callable(value):
                 return value
-    return getattr(socket, attribute, None)
+    value = getattr(socket, attribute, None)
+    if callable(value):
+        return None
+    return value
 
 
 def hash_inputs(*values):

--- a/nodes/list_find.py
+++ b/nodes/list_find.py
@@ -10,6 +10,7 @@ class NODE_OT_list_find(Node):
     def init(self, context):
         sock = self.inputs.new('ListNodeSocketType', 'List')
         sock.display_shape = 'SQUARE'
+        sock.items = []
         self.inputs.new('NodeSocketString', 'Name')
         self.outputs.new('SceneNodeSocketType', 'Scene')
         self.outputs.new('ObjectNodeSocketType', 'Object')
@@ -19,7 +20,9 @@ class NODE_OT_list_find(Node):
 
     def update(self):
         list_socket = self.inputs.get('List')
-        items = get_socket_value(list_socket, 'items')
+        items = get_socket_value(list_socket, 'items') or []
+        if callable(items):
+            items = []
         item_type = getattr(list_socket, 'items_type', '')
         name = get_socket_value(self.inputs.get('Name'), 'default_value') or ''
         idx = -1

--- a/nodes/list_index.py
+++ b/nodes/list_index.py
@@ -10,6 +10,7 @@ class NODE_OT_list_index(Node):
     def init(self, context):
         sock = self.inputs.new('ListNodeSocketType', 'List')
         sock.display_shape = 'SQUARE'
+        sock.items = []
         self.inputs.new('NodeSocketInt', 'Index')
         self.outputs.new('SceneNodeSocketType', 'Scene')
         self.outputs.new('ObjectNodeSocketType', 'Object')
@@ -18,7 +19,9 @@ class NODE_OT_list_index(Node):
 
     def update(self):
         list_socket = self.inputs.get('List')
-        items = get_socket_value(list_socket, 'items')
+        items = get_socket_value(list_socket, 'items') or []
+        if callable(items):
+            items = []
         item_type = getattr(list_socket, 'items_type', '')
         index = get_socket_value(self.inputs.get('Index'), 'default_value')
         try:

--- a/nodes/list_length.py
+++ b/nodes/list_length.py
@@ -10,10 +10,13 @@ class NODE_OT_list_length(Node):
     def init(self, context):
         sock = self.inputs.new('ListNodeSocketType', 'List')
         sock.display_shape = 'SQUARE'
+        sock.items = []
         self.outputs.new('NodeSocketInt', 'Length')
 
     def update(self):
-        items = get_socket_value(self.inputs.get('List'), 'items')
+        items = get_socket_value(self.inputs.get('List'), 'items') or []
+        if callable(items):
+            items = []
         length = len(items)
         if self.outputs:
             self.outputs['Length'].default_value = length

--- a/nodes/read_blend_file.py
+++ b/nodes/read_blend_file.py
@@ -11,10 +11,18 @@ class NODE_OT_read_blend_file(Node):
 
     def init(self, context):
         self.inputs.new('NodeSocketString', 'File Path')
-        self.outputs.new('ListNodeSocketType', 'Scenes').display_shape = 'SQUARE'
-        self.outputs.new('ListNodeSocketType', 'Objects').display_shape = 'SQUARE'
-        self.outputs.new('ListNodeSocketType', 'Materials').display_shape = 'SQUARE'
-        self.outputs.new('ListNodeSocketType', 'Worlds').display_shape = 'SQUARE'
+        scenes = self.outputs.new('ListNodeSocketType', 'Scenes')
+        scenes.display_shape = 'SQUARE'
+        scenes.items = []
+        objects = self.outputs.new('ListNodeSocketType', 'Objects')
+        objects.display_shape = 'SQUARE'
+        objects.items = []
+        materials = self.outputs.new('ListNodeSocketType', 'Materials')
+        materials.display_shape = 'SQUARE'
+        materials.items = []
+        worlds = self.outputs.new('ListNodeSocketType', 'Worlds')
+        worlds.display_shape = 'SQUARE'
+        worlds.items = []
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'filepath', text="")
@@ -31,7 +39,11 @@ class NODE_OT_read_blend_file(Node):
                 sock = self.outputs.get(name)
                 if not sock:
                     continue
-                items = list(getattr(sock, 'items', []))
+                items_attr = getattr(sock, 'items', [])
+                if callable(items_attr):
+                    items = []
+                else:
+                    items = list(items_attr)
                 for datablock in items:
                     try:
                         if getattr(datablock, 'users', 0) == 0:


### PR DESCRIPTION
## Summary
- initialize `.items` for all list socket outputs and inputs
- avoid calling built-in `items` method by returning `None` in `get_socket_value`
- guard against callable `items` attributes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855c88087b48330ad26bd52cf54f868