### PR TITLE
Add execution state flag to prevent unintended updates

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -29,14 +29,19 @@ class NodeExecutor:
 
     def execute_until(self, target_node=None):
         """Execute nodes in topological order up to ``target_node``."""
-        order = self._topological_order()
-        for node in order:
-            if hasattr(node, 'evaluate'):
-                node.evaluate()
-            elif hasattr(node, 'update'):
-                node.update()
-            if target_node and node == target_node:
-                break
+        tree = self.node_tree
+        tree.is_executing = True
+        try:
+            order = self._topological_order()
+            for node in order:
+                if hasattr(node, 'evaluate'):
+                    node.evaluate()
+                elif hasattr(node, 'update'):
+                    node.update()
+                if target_node and node == target_node:
+                    break
+        finally:
+            tree.is_executing = False
 
 
 import bpy

--- a/node_tree.py
+++ b/node_tree.py
@@ -156,6 +156,7 @@ class SCENE_NODES_TREE(NodeTree):
 
     active_node_name: bpy.props.StringProperty(name="Active Node", default="")
     dynamic_scene: _new_scene_property()
+    is_executing: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
 
     @classmethod
     def poll(cls, context):

--- a/nodes/add_collection.py
+++ b/nodes/add_collection.py
@@ -15,6 +15,10 @@ class NODE_OT_add_collection(Node):
         self.outputs.new('CollectionNodeSocketType', "Collection")
 
     def update(self):
+        tree = self.id_data
+        if not getattr(tree, "is_executing", False):
+            return
+
         output = self.outputs.get("Collection")
         if not output:
             return

--- a/nodes/create_scene.py
+++ b/nodes/create_scene.py
@@ -20,11 +20,14 @@ class NODE_OT_create_scene(Node):
 
 
     def update(self):
+        tree = self.id_data
+        if not getattr(tree, "is_executing", False):
+            return
+
         output = self.outputs.get("Scene")
         if not output:
             return
 
-        tree = self.id_data
         scene = getattr(tree, "dynamic_scene", None)
 
         name_socket = self.inputs.get("Name")

--- a/nodes/read_blend_file.py
+++ b/nodes/read_blend_file.py
@@ -28,6 +28,10 @@ class NODE_OT_read_blend_file(Node):
         layout.prop(self, 'filepath', text="")
 
     def update(self):
+        tree = self.id_data
+        if not getattr(tree, "is_executing", False):
+            return
+
         if self.outputs:
             collections = {
                 'Scenes': bpy.data.scenes,

--- a/nodes/render_scene.py
+++ b/nodes/render_scene.py
@@ -14,6 +14,10 @@ class NODE_OT_render_scene(Node):
 
 
     def update(self):
+        tree = self.id_data
+        if not getattr(tree, "is_executing", False):
+            return
+
         input_socket = self.inputs.get("Scene")
         if not input_socket:
             return

--- a/nodes/set_material.py
+++ b/nodes/set_material.py
@@ -16,6 +16,10 @@ class NODE_OT_set_material(Node):
         self.outputs.new('ObjectNodeSocketType', "Object")
 
     def update(self):
+        tree = self.id_data
+        if not getattr(tree, "is_executing", False):
+            return
+
         obj = get_socket_value(self.inputs.get("Object"), 'object')
         mat = get_socket_value(self.inputs.get("Material"), 'material')
         if obj:

--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -17,6 +17,10 @@ class NODE_OT_set_world(Node):
 
 
     def update(self):
+        tree = self.id_data
+        if not getattr(tree, "is_executing", False):
+            return
+
         scene = get_socket_value(self.inputs.get("Scene"), 'scene')
         world = get_socket_value(self.inputs.get("World"), 'world')
         if scene and world:


### PR DESCRIPTION
## Summary
- add `is_executing` property to `SCENE_NODES_TREE`
- toggle this property while nodes execute
- early return from update() of nodes that create or modify data when not executing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855e1aa040c8330849c73389f30fb43