### PR TITLE
Add node execute buttons

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -49,10 +49,7 @@ from bpy.types import Operator
 
 
 def update_node_icons(tree):
-    """Update header icons on all nodes to reflect execution state."""
-    active = getattr(tree, 'active_node_name', '')
-    for node in tree.nodes:
-        node.bl_icon = 'RADIOBUT_ON' if node.name == active else 'RADIOBUT_OFF'
+    """Redraw node editors so execution buttons refresh their icons."""
     for window in bpy.context.window_manager.windows:
         for area in window.screen.areas:
             if area.type == 'NODE_EDITOR':

--- a/nodes/add_collection.py
+++ b/nodes/add_collection.py
@@ -14,6 +14,11 @@ class NODE_OT_add_collection(Node):
     def init(self, context):
         self.outputs.new('CollectionNodeSocketType', "Collection")
 
+    def draw_buttons(self, context, layout):
+        icon = 'RADIOBUT_ON' if self.id_data.active_node_name == self.name else 'RADIOBUT_OFF'
+        op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
+        op.node_name = self.name
+
     def update(self):
         tree = self.id_data
         if not getattr(tree, "is_executing", False):

--- a/nodes/create_scene.py
+++ b/nodes/create_scene.py
@@ -16,6 +16,9 @@ class NODE_OT_create_scene(Node):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'scene_name', text="")
+        icon = 'RADIOBUT_ON' if self.id_data.active_node_name == self.name else 'RADIOBUT_OFF'
+        op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
+        op.node_name = self.name
 
 
 

--- a/nodes/render_scene.py
+++ b/nodes/render_scene.py
@@ -11,6 +11,11 @@ class NODE_OT_render_scene(Node):
     def init(self, context):
         self.inputs.new('SceneNodeSocketType', "Scene")
 
+    def draw_buttons(self, context, layout):
+        icon = 'RADIOBUT_ON' if self.id_data.active_node_name == self.name else 'RADIOBUT_OFF'
+        op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
+        op.node_name = self.name
+
 
 
     def update(self):

--- a/nodes/set_material.py
+++ b/nodes/set_material.py
@@ -15,6 +15,11 @@ class NODE_OT_set_material(Node):
         self.inputs.new('MaterialNodeSocketType', "Material")
         self.outputs.new('ObjectNodeSocketType', "Object")
 
+    def draw_buttons(self, context, layout):
+        icon = 'RADIOBUT_ON' if self.id_data.active_node_name == self.name else 'RADIOBUT_OFF'
+        op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
+        op.node_name = self.name
+
     def update(self):
         tree = self.id_data
         if not getattr(tree, "is_executing", False):

--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -14,6 +14,11 @@ class NODE_OT_set_world(Node):
         self.inputs.new('WorldNodeSocketType', "World")
         self.outputs.new('SceneNodeSocketType', "Scene")
 
+    def draw_buttons(self, context, layout):
+        icon = 'RADIOBUT_ON' if self.id_data.active_node_name == self.name else 'RADIOBUT_OFF'
+        op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
+        op.node_name = self.name
+
 
 
     def update(self):


### PR DESCRIPTION
## Summary
- refresh node editors instead of changing bl_icon
- add execution button to Create Scene node
- add execution button to Render Scene node
- add execution button to Add Collection node
- add execution button to Set Material node
- add execution button to Set World node

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855e3248454833083884eb8f8c4cefd