### PR TITLE
Fix clearing list socket items

### DIFF
--- a/nodes/read_blend_file.py
+++ b/nodes/read_blend_file.py
@@ -54,7 +54,10 @@ class NODE_OT_read_blend_file(Node):
                             data.remove(datablock)
                     except Exception:
                         pass
-                sock.items.clear()
+                if isinstance(sock.items, list):
+                    sock.items.clear()
+                else:
+                    sock.items = []
 
         path = None
         path_socket = self.inputs.get('File Path')


### PR DESCRIPTION
## Summary
- handle built-in `items` method in `read_blend_file` node

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855e6f6ebfc8330b23f598e05dd709c