### PR TITLE
Fix socket items clearing in read_blend_file

### DIFF
--- a/nodes/read_blend_file.py
+++ b/nodes/read_blend_file.py
@@ -54,7 +54,10 @@ class NODE_OT_read_blend_file(Node):
                             data.remove(datablock)
                     except Exception:
                         pass
-                sock.items.clear()
+                if isinstance(items_attr, list):
+                    items_attr.clear()
+                else:
+                    sock.items = []
 
         path = None
         path_socket = self.inputs.get('File Path')


### PR DESCRIPTION
## Summary
- avoid AttributeError when clearing socket items in `read_blend_file`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e6f6ebfc8330b23f598e05dd709c