### PR TITLE
Add import type enum socket to Read Blend File node

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Once enabled, open the *Geometry Node Editor* and switch the tree type to **Scen
 - **Add Collection** — creates a new collection datablock.
 - **Set Material** — assign a material to an object.
 - **Set World** — assign a world to a scene.
-- **Read Blend File** — load datablock names from an external blend file.
+- **Read Blend File** — load datablock names from an external blend file. Choose
+  the import type via its **Import Type** socket (Append or Link).
 - **Input Nodes** — provide basic values (String, Bool, Float, Integer, Vector, Object, Material, World).
 - **List Nodes** — work with semicolon separated string lists (Length, Item by Index, Find Item).
 

--- a/__init__.py
+++ b/__init__.py
@@ -24,6 +24,7 @@ from .node_tree import (
     MaterialNodeSocket,
     WorldNodeSocket,
     ListNodeSocket,
+    ImportTypeNodeSocket,
     SCENE_NODES_TREE,
 )
 from .nodes.create_scene import NODE_OT_create_scene
@@ -54,6 +55,7 @@ classes = (
     MaterialNodeSocket,
     WorldNodeSocket,
     ListNodeSocket,
+    ImportTypeNodeSocket,
     SCENE_NODES_TREE,
     NODE_OT_create_scene,
     NODE_OT_render_scene,

--- a/node_tree.py
+++ b/node_tree.py
@@ -121,6 +121,27 @@ class ListNodeSocket(NodeSocket):
         return colors.get(self.items_type, (0.8, 0.8, 0.1, 1.0))
 
 
+class ImportTypeNodeSocket(NodeSocket):
+    """Socket to choose how libraries are imported."""
+    bl_idname = 'ImportTypeNodeSocketType'
+    bl_label = 'Import Type'
+
+    import_type: bpy.props.EnumProperty(
+        name="Import Type",
+        items=[
+            ('APPEND', 'Append', 'Append data blocks'),
+            ('LINK', 'Link', 'Link data blocks'),
+        ],
+        default='APPEND',
+    )
+
+    def draw(self, context, layout, node, text):
+        layout.prop(self, 'import_type', text=text)
+
+    def draw_color(self, context, node):
+        return (0.5, 0.5, 0.8, 1.0)
+
+
 def get_socket_value(socket, attribute):
     """Retrieve the value from a socket, considering links."""
     if not socket:

--- a/nodes/read_blend_file.py
+++ b/nodes/read_blend_file.py
@@ -1,6 +1,8 @@
 import bpy
 from bpy.types import Node
 
+from ..node_tree import get_socket_value
+
 
 class NODE_OT_read_blend_file(Node):
     bl_idname = 'NODE_OT_read_blend_file'
@@ -11,6 +13,8 @@ class NODE_OT_read_blend_file(Node):
 
     def init(self, context):
         self.inputs.new('NodeSocketString', 'File Path')
+        sock = self.inputs.new('ImportTypeNodeSocketType', 'Import Type')
+        sock.import_type = 'APPEND'
         scenes = self.outputs.new('ListNodeSocketType', 'Scenes')
         scenes.display_shape = 'SQUARE'
         scenes.items = []
@@ -71,8 +75,10 @@ class NODE_OT_read_blend_file(Node):
             path = self.filepath
         if not path:
             return
+        import_type = get_socket_value(self.inputs.get('Import Type'), 'import_type') or 'APPEND'
+        link = import_type == 'LINK'
         try:
-            with bpy.data.libraries.load(path, link=False) as (data_from, data_to):
+            with bpy.data.libraries.load(path, link=link) as (data_from, data_to):
                 data_to.scenes = list(data_from.scenes)
                 data_to.objects = list(data_from.objects)
                 data_to.materials = list(data_from.materials)


### PR DESCRIPTION
## Summary
- add `ImportTypeNodeSocket` for selecting append vs link
- expose new socket in `Read Blend File` node and use it when loading libraries
- register the new socket class with the addon
- document the import type option in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855e6e3fc9883309417d2330b4b2542