### PR TITLE
Move execute operator to scene output sockets

### DIFF
--- a/node_tree.py
+++ b/node_tree.py
@@ -33,6 +33,11 @@ class SceneNodeSocket(NodeSocket):
     # socket color
     def draw(self, context, layout, node, text):
         layout.label(text=text)
+        if self.is_output and (hasattr(node, 'update') or hasattr(node, 'evaluate')):
+            tree = node.id_data
+            icon = 'RADIOBUT_ON' if getattr(tree, 'active_node_name', '') == node.name else 'RADIOBUT_OFF'
+            op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
+            op.node_name = node.name
 
     def draw_color(self, context, node):
         return (0.6, 0.8, 0.2, 1.0)

--- a/nodes/add_collection.py
+++ b/nodes/add_collection.py
@@ -15,9 +15,7 @@ class NODE_OT_add_collection(Node):
         self.outputs.new('CollectionNodeSocketType', "Collection")
 
     def draw_buttons(self, context, layout):
-        icon = 'RADIOBUT_ON' if self.id_data.active_node_name == self.name else 'RADIOBUT_OFF'
-        op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
-        op.node_name = self.name
+        pass
 
     def update(self):
         tree = self.id_data

--- a/nodes/create_scene.py
+++ b/nodes/create_scene.py
@@ -16,9 +16,6 @@ class NODE_OT_create_scene(Node):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'scene_name', text="")
-        icon = 'RADIOBUT_ON' if self.id_data.active_node_name == self.name else 'RADIOBUT_OFF'
-        op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
-        op.node_name = self.name
 
 
 

--- a/nodes/set_material.py
+++ b/nodes/set_material.py
@@ -16,9 +16,7 @@ class NODE_OT_set_material(Node):
         self.outputs.new('ObjectNodeSocketType', "Object")
 
     def draw_buttons(self, context, layout):
-        icon = 'RADIOBUT_ON' if self.id_data.active_node_name == self.name else 'RADIOBUT_OFF'
-        op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
-        op.node_name = self.name
+        pass
 
     def update(self):
         tree = self.id_data

--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -15,9 +15,7 @@ class NODE_OT_set_world(Node):
         self.outputs.new('SceneNodeSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
-        icon = 'RADIOBUT_ON' if self.id_data.active_node_name == self.name else 'RADIOBUT_OFF'
-        op = layout.operator('scene_nodes.execute_to_node', text='', icon=icon, emboss=False)
-        op.node_name = self.name
+        pass
 
 
 


### PR DESCRIPTION
## Summary
- shift execution control from node headers to Scene output sockets
- streamline header UI of collection, material, world and scene nodes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68566779c9d0833092817954dcb8635d