### PR TITLE
Add group IO nodes and file socket

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,6 +26,7 @@ from .node_tree import (
     WorldNodeSocket,
     ListNodeSocket,
     ImportTypeNodeSocket,
+    FileNodeSocket,
     SCENE_NODES_TREE,
 )
 from .nodes.create_scene import NODE_OT_create_scene
@@ -45,6 +46,8 @@ from .nodes.read_blend_file import NODE_OT_read_blend_file
 from .nodes.list_index import NODE_OT_list_index
 from .nodes.list_find import NODE_OT_list_find
 from .nodes.list_length import NODE_OT_list_length
+from .nodes.group_input import NODE_OT_group_input
+from .nodes.group_output import NODE_OT_group_output
 from .executor import SCENE_OT_execute_to_node
 from .handlers import register_handlers, unregister_handlers
 
@@ -58,6 +61,7 @@ classes = (
     WorldNodeSocket,
     ListNodeSocket,
     ImportTypeNodeSocket,
+    FileNodeSocket,
     SCENE_NODES_TREE,
     NODE_OT_create_scene,
     NODE_OT_render_scene,
@@ -76,6 +80,8 @@ classes = (
     NODE_OT_list_index,
     NODE_OT_list_find,
     NODE_OT_list_length,
+    NODE_OT_group_input,
+    NODE_OT_group_output,
     SCENE_OT_execute_to_node,
 )
 
@@ -104,6 +110,8 @@ node_categories = [
         NodeItem(NODE_OT_list_index.bl_idname),
         NodeItem(NODE_OT_list_find.bl_idname),
         NodeItem(NODE_OT_list_length.bl_idname),
+        NodeItem(NODE_OT_group_input.bl_idname),
+        NodeItem(NODE_OT_group_output.bl_idname),
     ]),
 ]
 

--- a/node_tree.py
+++ b/node_tree.py
@@ -152,6 +152,20 @@ class ImportTypeNodeSocket(NodeSocket):
         return (0.5, 0.5, 0.8, 1.0)
 
 
+class FileNodeSocket(NodeSocket):
+    """Socket holding a path to a .blend file."""
+    bl_idname = 'FileNodeSocketType'
+    bl_label = 'File Socket'
+
+    filepath: bpy.props.StringProperty(name="File Path", subtype='FILE_PATH')
+
+    def draw(self, context, layout, node, text):
+        layout.label(text=text)
+
+    def draw_color(self, context, node):
+        return (0.6, 0.6, 0.6, 1.0)
+
+
 def get_socket_value(socket, attribute):
     """Retrieve the value from a socket, considering links."""
     if not socket:

--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -1,0 +1,20 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_group_input(Node):
+    bl_idname = 'NODE_OT_group_input'
+    bl_label = 'Group Input'
+    bl_icon = 'GROUP_VERTEX'
+
+    def init(self, context):
+        self.outputs.new('SceneNodeSocketType', 'Scene')
+        self.outputs.new('FileNodeSocketType', 'File')
+
+    def update(self):
+        scene_out = self.outputs.get('Scene')
+        file_out = self.outputs.get('File')
+        if scene_out:
+            scene_out.scene = bpy.context.scene
+        if file_out:
+            file_out.filepath = bpy.data.filepath

--- a/nodes/group_output.py
+++ b/nodes/group_output.py
@@ -1,0 +1,15 @@
+import bpy
+from bpy.types import Node
+
+
+class NODE_OT_group_output(Node):
+    bl_idname = 'NODE_OT_group_output'
+    bl_label = 'Group Output'
+    bl_icon = 'GROUP_VERTEX'
+
+    def init(self, context):
+        self.inputs.new('SceneNodeSocketType', 'Scene')
+        self.inputs.new('FileNodeSocketType', 'File')
+
+    def update(self):
+        pass


### PR DESCRIPTION
## Summary
- add `FileNodeSocket` for referencing blend files
- implement `Group Input` and `Group Output` nodes
- expose new nodes and socket types in addon registration

## Testing
- `python -m py_compile __init__.py node_tree.py nodes/*.py executor.py handlers.py user_edits.py`

------
https://chatgpt.com/codex/tasks/task_e_6857b9c04df48330a0ae9a44deee60ac