### PR TITLE
Capture start scene for group input

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -50,6 +50,8 @@ class NodeExecutor:
     def execute_until(self, target_node=None):
         """Execute nodes in topological order up to ``target_node``."""
         tree = self.node_tree
+        import bpy
+        tree.start_scene = bpy.context.scene
         tree.is_executing = True
         try:
             order = self._topological_order()

--- a/node_tree.py
+++ b/node_tree.py
@@ -201,6 +201,7 @@ class SCENE_NODES_TREE(NodeTree):
 
     active_node_name: bpy.props.StringProperty(name="Active Node", default="")
     dynamic_scene: _new_scene_property()
+    start_scene: _new_scene_property()
     is_executing: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
 
     @classmethod

--- a/nodes/create_scene.py
+++ b/nodes/create_scene.py
@@ -1,7 +1,7 @@
 import bpy
 from bpy.types import Node
 
-from ..node_tree import SceneNodeSocket
+from ..node_tree import SceneNodeSocket, get_socket_value, hash_inputs
 
 class NODE_OT_create_scene(Node):
     bl_idname = 'NODE_OT_create_scene'
@@ -11,6 +11,7 @@ class NODE_OT_create_scene(Node):
     scene_name: bpy.props.StringProperty(name="Scene Name", default="")
 
     def init(self, context):
+        self.inputs.new('SceneNodeSocketType', "Scene")
         self.inputs.new('NodeSocketString', "Name")
         self.outputs.new('SceneNodeSocketType', "Scene")
 
@@ -26,6 +27,12 @@ class NODE_OT_create_scene(Node):
 
         output = self.outputs.get("Scene")
         if not output:
+            return
+
+        input_scene = get_socket_value(self.inputs.get("Scene"), 'scene')
+        if input_scene:
+            output.scene = input_scene
+            self.node_hash = hash_inputs(input_scene)
             return
 
         scene = getattr(tree, "dynamic_scene", None)
@@ -59,3 +66,4 @@ class NODE_OT_create_scene(Node):
                 scene.name = name
 
         output.scene = scene
+        self.node_hash = hash_inputs(scene, name)

--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -15,6 +15,7 @@ class NODE_OT_group_input(Node):
         scene_out = self.outputs.get('Scene')
         file_out = self.outputs.get('File')
         if scene_out:
-            scene_out.scene = bpy.context.scene
+            tree = self.id_data
+            scene_out.scene = getattr(tree, 'start_scene', bpy.context.scene)
         if file_out:
             file_out.filepath = bpy.data.filepath


### PR DESCRIPTION
## Summary
- store the active scene at execution start in `SCENE_NODES_TREE`
- expose the stored scene from the Group Input node
- allow Create Scene to accept a scene input and reuse it

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857c7e9ddc4833083dcc81f03f1b386